### PR TITLE
Implement flexible operation modes and retraining

### DIFF
--- a/collectors/binance.py
+++ b/collectors/binance.py
@@ -3,13 +3,22 @@ import requests
 from datetime import datetime
 
 
-def coletar_dados(ativo: str, timeframe: str = "1m", limite: int = 500) -> pd.DataFrame:
+def coletar_dados(
+    ativo: str,
+    timeframe: str = "1m",
+    limite: int = 500,
+    start_time: datetime | None = None,
+) -> pd.DataFrame:
     """Coleta dados de candles da API da Binance."""
-    url = (
-        "https://api.binance.com/api/v3/klines"
-        f"?symbol={ativo}&interval={timeframe}&limit={limite}"
-    )
-    resp = requests.get(url, timeout=10)
+    url = "https://api.binance.com/api/v3/klines"
+    params = {
+        "symbol": ativo,
+        "interval": timeframe,
+        "limit": limite,
+    }
+    if start_time:
+        params["startTime"] = int(start_time.timestamp() * 1000)
+    resp = requests.get(url, params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json()
 

--- a/collectors/coletor_universal.py
+++ b/collectors/coletor_universal.py
@@ -1,36 +1,23 @@
-from core.utils import identificar_fonte
-from collectors import binance, iqoption
-import requests
+from __future__ import annotations
+
+from datetime import datetime
+
 import pandas as pd
 
+from core.utils import identificar_fonte
+from collectors import binance, iqoption
 
-def coletar_dados(ativo, timeframe="5m", limite=1000, start_time=None):
-    url = "https://api.binance.com/api/v3/klines"
-    params = {
-        "symbol": ativo,
-        "interval": timeframe,
-        "limit": limite
-    }
 
-    if start_time:
-        params["startTime"] = int(pd.to_datetime(start_time).timestamp() * 1000)
-
-    response = requests.get(url, params=params)
-    if response.status_code != 200:
-        print("Erro na API da Binance:", response.text)
-        return pd.DataFrame()
-
-    data = response.json()
-    candles = []
-    for c in data:
-        candles.append({
-            "open_time": pd.to_datetime(c[0], unit="ms"),
-            "open": float(c[1]),
-            "high": float(c[2]),
-            "low": float(c[3]),
-            "close": float(c[4]),
-            "volume": float(c[5]),
-            "close_time": pd.to_datetime(c[6], unit="ms"),
-        })
-
-    return pd.DataFrame(candles)
+def coletar_dados(
+    ativo: str,
+    timeframe: str = "5m",
+    limite: int = 1000,
+    start_time: datetime | None = None,
+) -> pd.DataFrame:
+    """Roteia a coleta de dados para a API apropriada."""
+    fonte = identificar_fonte(ativo)
+    if fonte == "binance":
+        return binance.coletar_dados(ativo.replace("-", ""), timeframe, limite, start_time)
+    if fonte == "iqoption":
+        return iqoption.coletar_dados(ativo, timeframe, limite, start_time)
+    return pd.DataFrame()

--- a/collectors/iqoption.py
+++ b/collectors/iqoption.py
@@ -1,7 +1,12 @@
 import pandas as pd
 
 
-def coletar_dados(ativo: str, timeframe: str = "1m", limite: int = 500) -> pd.DataFrame:
+def coletar_dados(
+    ativo: str,
+    timeframe: str = "1m",
+    limite: int = 500,
+    start_time=None,
+) -> pd.DataFrame:
     """Coleta dados da IQ Option (placeholder)."""
     # A integração real deve ser implementada futuramente.
     return pd.DataFrame()

--- a/core/config.py
+++ b/core/config.py
@@ -6,3 +6,11 @@ STOP_DIARIO = 3
 META_DIARIA = 5
 FONTE_PRIORITARIA = "binance"
 DB_PATH = "data/sinais.db"
+
+# Modo de operação do sistema: "opcao_binaria" ou "daytrade"
+MODO_OPERACAO = "opcao_binaria"
+
+# Configurações específicas para cada modo
+EXPIRACAO_CANDLES = 1  # utilizado para opcao_binaria
+STOP_LOSS_PERCENT = 0.003  # utilizado para daytrade
+TAKE_PROFIT_PERCENT = 0.007  # utilizado para daytrade

--- a/estrategias/__init__.py
+++ b/estrategias/__init__.py
@@ -1,0 +1,1 @@
+# Estratégias e utilidades

--- a/estrategias/avaliar_resultado.py
+++ b/estrategias/avaliar_resultado.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from core.config import (
+    MODO_OPERACAO,
+    EXPIRACAO_CANDLES,
+    STOP_LOSS_PERCENT,
+    TAKE_PROFIT_PERCENT,
+)
+
+
+def avaliar_resultado_sinal(sinal: Dict, df_candles: pd.DataFrame) -> str:
+    """Avalia se um sinal resultou em WIN ou LOSS."""
+    direcao = sinal.get("sinal", "").upper()
+
+    if df_candles.empty:
+        return "LOSS"
+
+    if MODO_OPERACAO == "opcao_binaria":
+        expiracao = int(sinal.get("expiracao", EXPIRACAO_CANDLES))
+        if len(df_candles) <= expiracao:
+            return "LOSS"
+        entrada = df_candles.iloc[0]["close"]
+        saida = df_candles.iloc[expiracao]["close"]
+        if direcao in {"CALL", "COMPRA", "ALTA"}:
+            return "WIN" if saida > entrada else "LOSS"
+        else:
+            return "WIN" if saida < entrada else "LOSS"
+
+    # daytrade
+    entrada = df_candles.iloc[0]["close"]
+    tp_percent = float(sinal.get("tp", TAKE_PROFIT_PERCENT))
+    sl_percent = float(sinal.get("sl", STOP_LOSS_PERCENT))
+
+    if direcao in {"CALL", "COMPRA", "ALTA"}:
+        tp = entrada * (1 + tp_percent)
+        sl = entrada * (1 - sl_percent)
+        for _, candle in df_candles.iloc[1:].iterrows():
+            if candle["high"] >= tp:
+                return "WIN"
+            if candle["low"] <= sl:
+                return "LOSS"
+        return "WIN" if df_candles.iloc[-1]["close"] > entrada else "LOSS"
+    else:
+        tp = entrada * (1 - tp_percent)
+        sl = entrada * (1 + sl_percent)
+        for _, candle in df_candles.iloc[1:].iterrows():
+            if candle["low"] <= tp:
+                return "WIN"
+            if candle["high"] >= sl:
+                return "LOSS"
+        return "WIN" if df_candles.iloc[-1]["close"] < entrada else "LOSS"

--- a/train/retrain_model.py
+++ b/train/retrain_model.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+
+from db import database
+from agents import agente_ia
+
+MODEL_OUT = Path("models/modelo_atualizado.pkl")
+
+
+def carregar_dataset():
+    sinais = database.buscar_sinais_com_resultado()
+    if not sinais:
+        return pd.DataFrame(), []
+
+    registros = []
+    targets = []
+    for s in sinais:
+        candle = database.buscar_candle_por_tempo(s["ativo"], s["candle_time"])
+        if candle is None:
+            continue
+        historico = database.buscar_candles(s["ativo"], 200)
+        cols = ["ativo", "open_time", "open", "high", "low", "close", "volume"]
+        df = pd.DataFrame(historico, columns=cols)
+        df["open_time"] = pd.to_datetime(df["open_time"])
+        df = df.sort_values("open_time")
+        df_feat = agente_ia._preparar_features(df)
+        linha = df_feat[df_feat["open_time"] == candle["open_time"]]
+        if linha.empty:
+            continue
+        registros.append(linha[agente_ia._FEATURES].iloc[0].values)
+        targets.append(1 if s["resultado"] == "WIN" else 0)
+    if not registros:
+        return pd.DataFrame(), []
+    X = pd.DataFrame(registros, columns=agente_ia._FEATURES)
+    return X, targets
+
+
+def main() -> None:
+    X, y = carregar_dataset()
+    if X.empty:
+        print("Nenhum dado para re-treinamento.")
+        return
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X, y)
+    MODEL_OUT.parent.mkdir(exist_ok=True, parents=True)
+    joblib.dump(model, MODEL_OUT)
+    print(f"Modelo salvo em {MODEL_OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new configuration options for binary vs daytrade
- update universal collector to route to proper API
- expand database schema for signal metadata and results
- implement result evaluation logic
- add retraining script to fit model from historical signals
- adjust pipeline to store metadata and evaluate pending signals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535f392910832e8d7f2daa78534d9d